### PR TITLE
list of funding options collected over the years

### DIFF
--- a/fundingOptions.md
+++ b/fundingOptions.md
@@ -1,0 +1,19 @@
+# Funding
+
+If you know of any grants or channels to apply to resources that would allow developers to focus on building their Solid applications, please do share them on this list by submitting a pull request.
+
+- [Consensus Community Innovation Grants](http://agree.org/)
+- [DuckDuckGo Donations](https://duckduckgo.com/donations)
+- [EU DAPSI](https://dapsi.ngi.eu/)
+- [GitHub Sponsors](https://github.com/sponsors)
+- [Grant for the web](https://forum.grantfortheweb.org/t/call-for-proposals-early-2020/959)
+- [Je Data de Baas](https://www.sidnfonds.nl/nieuws/follow-up-call-je-data-de-baas) by SIDN
+- [Ledger Project](https://ledgerproject.eu)
+- [Mozilla Open Science Mini Grants](https://docs.google.com/document/d/1EJXg9G01CG7dBRbmbZzFnB9Bex2ibAVza_4xE8iqQqI/edit)
+- [Mozilla Open Source Support](https://www.mozilla.org/en-US/moss/)
+- [NGI Pointer](https://www.ngi.eu/ngi-projects/ngi-pointer/)
+- [NLNET Foundation](https://nlnet.nl)
+- [Next Generation Internet](https://www.ngi.eu)
+- [SIDN Fonds](https://www.sidnfonds.nl/excerpt/)
+- [Slack Fund](https://slack.com/developers/fund)
+- [The Knight Foundation](https://knightfoundation.org) and [The Knight Foundation for Technology Innovation](https://knightfoundation.org/programs/technology)


### PR DESCRIPTION
This is initially copied over from the website: https://github.com/solid/solidproject.org/blob/8a7342e449c236a91114d5d41acfbd6ebf38f443/pages/funding.md?plain=1#L3
I believe this page will not exist with the new content changes.